### PR TITLE
Fix model cleanup issue

### DIFF
--- a/rpdc.py
+++ b/rpdc.py
@@ -496,10 +496,9 @@ for nextModelFile in filesToProcess:
 
         # 2) obtain signed URLs for upload
         if (modelLabel != ""):
-            uploadURLs = getUploadURLs(fileExt, accessToken, modelLabel,baseUrl)
+            uploadURLs = getUploadURLs(fileExt, accessToken, modelLabel, baseUrl)
         else:
-            uploadURLs = getUploadURLs(fileExt, accessToken, nextModelFileWithoutExt,baseUrl)
-            uploadURLs = getUploadURLs(fileExt, accessToken, nextModelFileWithoutExtAndPath,baseUrl)
+            uploadURLs = getUploadURLs(fileExt, accessToken, nextModelFileWithoutExtAndPath, baseUrl)
 
         if (uploadURLs is None):
             print("Couldn't obtain signed upload URLs from server.")

--- a/schema/workflow_schema_v2_9.schema.json
+++ b/schema/workflow_schema_v2_9.schema.json
@@ -262,7 +262,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["bakeAOMap", "bakeNormalMap", "bakingQuality", "normalsShading", "alphaBlendToMask"]
+          "required": ["bakeAOMap", "bakeNormalMap", "bakingQuality"]
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
When using the script, it leaves behind corrupt uploads, even when using the cleanup flag. 
This MR aims to resolve this issue, caused by a duplicate request for a signed upload URL.